### PR TITLE
Update autoprefixer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,6 @@
 {
   "name": "new-project",
   "version": "0.0.0",
-  "dependencies": {
-    "flexbox-mixins": "~1.1.0"
-  },
   "devDependencies": {
     "components-font-awesome": "~4.3.0",
     "jquery": "~2.1.4"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -108,7 +108,7 @@ gulp.task('clean', function(cb) {
 
 // build task to populate the dist folder
 gulp.task('build', ['clean'], function() {
-  gulp.start('styles', 'scripts', 'html');
+  gulp.start('styles', 'scripts', 'third-party', 'html');
 });
 
 // watch task

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,8 @@
 // Load plugins
 var gulp = require('gulp'),
     less = require('gulp-less'),
-    autoprefixer = require('gulp-autoprefixer'),
+    autoprefixer = require('autoprefixer'),
+    postcss = require('gulp-postcss'),
     minifycss = require('gulp-minify-css'),
     imagemin = require('gulp-imagemin'),
     pngquant = require('imagemin-pngquant'),
@@ -15,7 +16,9 @@ var gulp = require('gulp'),
     uglify = require('gulp-uglify'),
     browserSync = require('browser-sync'),
     plumber = require('gulp-plumber'),
-    bower = require('main-bower-files');
+    processors = [
+      autoprefixer({browsers: ['last 3 versions']})
+    ];
 
 var bowerDir = './bower_components';
 
@@ -40,15 +43,15 @@ gulp.task('icons', function() { 
 // compile LESS to CSS
 // run autoprefixer
 // minify compiled CSS
-gulp.task('compile-less', function() {
+gulp.task('styles', function() {
   return gulp.src('src/css/main.less')
     .pipe(plumber())
     .pipe(less())
-    .pipe(autoprefixer())
+    .pipe(postcss(processors))
     .pipe(rename('main.css'))
     .pipe(gulp.dest('dist/css'))
     .pipe(rename({suffix: '.min'}))
-    .pipe(minifycss())
+    .pipe(minifycss({advanced: false, keepSpecialComments: 0}))
     .pipe(gulp.dest('dist/css'))
     .pipe(browserSync.reload({stream: true}));
 });
@@ -59,10 +62,10 @@ gulp.task('third-party', function() {
   return gulp.src(bowerDir + '/jquery/dist/jquery.js')
     .pipe(plumber())
     .pipe(concat('third-party.js'))
-    .pipe(gulp.dest('dist/js'))
+    .pipe(gulp.dest('dist/lib'))
     .pipe(rename({suffix: '.min'}))
     .pipe(uglify())
-    .pipe(gulp.dest('dist/js'))
+    .pipe(gulp.dest('dist/lib'))
     .pipe(browserSync.reload({stream: true}));
 });
 
@@ -103,21 +106,14 @@ gulp.task('clean', function(cb) {
   del(['dist/css', 'dist/js', 'dist/img', 'dist/lib'], cb)
 });
 
-// install main bower files. You still need to include these in your index.html. Path will be ./lib/component_name/main_file.ext
-gulp.task('bower', function() {
-  return gulp.src(bower(), { base: './bower_components' })
-    .pipe(plumber())
-    .pipe(gulp.dest('dist/lib'))
-});
-
 // build task to populate the dist folder
 gulp.task('build', ['clean'], function() {
-  gulp.start('bower', 'compile-less', 'scripts', 'html');
+  gulp.start('styles', 'scripts', 'html');
 });
 
 // watch task
 gulp.task('watch', function() {
-  gulp.watch('src/css/*.less', ['compile-less']);
+  gulp.watch('src/css/*.less', ['styles']);
   gulp.watch('src/css/main.css', ['bs-reload']);
   gulp.watch('src/*.html', ['html']);
   gulp.watch('src/img/*', ['images']);

--- a/package.json
+++ b/package.json
@@ -17,20 +17,20 @@
   },
   "homepage": "https://github.com/mmcbride1007/new-project",
   "devDependencies": {
+    "autoprefixer": "^6.1.0",
     "browser-sync": "^2.2.3",
     "del": "^1.2.0",
     "gulp": "^3.8.11",
-    "gulp-autoprefixer": "^2.3.1",
     "gulp-concat": "^2.5.2",
     "gulp-imagemin": "^2.3.0",
     "gulp-less": "^3.0.1",
     "gulp-minify-css": "^1.1.6",
     "gulp-plumber": "^1.0.1",
+    "gulp-postcss": "^6.0.1",
     "gulp-rename": "^1.2.0",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.4",
     "gulp-watch": "^4.1.1",
-    "imagemin-pngquant": "^4.1.0",
-    "main-bower-files": "^2.8.0"
+    "imagemin-pngquant": "^4.1.0"
   }
 }

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1,1 +1,20 @@
-// your LESS goes here
+// your styles go here. Here are some simple resets.
+html {
+  font-size: 16px;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  box-sizing: border-box;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+body {
+  margin: 0;
+}
+
+img {
+  max-width: 100%;
+}

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1,1 +1,1 @@
-@import "../../bower_components/flexbox-mixins/flexbox.less";
+// your LESS goes here

--- a/src/index.html
+++ b/src/index.html
@@ -17,6 +17,7 @@
     <h1>Welcome to your new project!</h1>
 
     <!-- include any additional scripts here. Gulp will compile anything in the JS directory into main.min.js. -->
+    <script src="lib/third-party.min.js"></script>
     <script src="js/main.min.js"></script>
   </body>
 </html>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,4 +1,4 @@
 // your javascript goes in here
-function init() {
-  console.log('Hello, world');
-}
+$(document).ready(function() {
+  console.log('Hello world!');
+})


### PR DESCRIPTION
- Updates autoprefixer to use the new postcss style
- Removes flexbox mixins (not necessary since we use autoprefixer)
- Removes `main-bower-files` plugin (not really needed)
- Gives some basic reset styles
